### PR TITLE
Multiple Makefile changes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,35 +29,32 @@ MKDIR=mkdir -m 755 -p
 # in accord with usual conventions, the first target is named 'all'
 all: reference_genome
 
-$(starBinDir)/STAR: $(starSrcDir)
-	cd $< && make 
+$(starBinDir)/STAR: | $(starSrcDir)
+	cd $(word 1, $|) && $(MAKE)
 
 $(starSrcDir): ${DNFA_starRoot}/2.6.0a.tar.gz
 	cd $(<D) && tar -xzf $<
 
-${DNFA_starRoot}/2.6.0a.tar.gz:
-	$(MKDIR) $(@D)
+${DNFA_starRoot}/2.6.0a.tar.gz: | $$(@D)
 	cd $(@D) && wget -nc https://github.com/alexdobin/STAR/archive/$(@F)
 
-$(gtf): $$@.gz  # this requires .SECONDEXPANSION
+$(gtf): $$@.gz
 	cd $(@D) && $(GUNZIP) $<
 
-$(gtf).gz:
-	$(MKDIR) $(@D)
+$(gtf).gz: | $$(@D)
 	cd $(@D) && wget -nc $(ensemblBase)/gtf/homo_sapiens/$(@F)
 
-$(fa): $$@.gz  # this requires .SECONDEXPANSION
+$(fa): $$@.gz
 	cd $(@D) && $(GUNZIP) $<
 
-$(fa).gz:
-	$(MKDIR) $(@D)
+$(fa).gz: | $$(@D)
 	cd $(@D) && wget -nc $(ensemblBase)/fasta/homo_sapiens/dna/$(@F)
 
-# 'SA' is one of many alignment output files, but used as a proxy for the whole alignment step
+# 'SA' (containing a suffix array) is one of many alignment output files,
+# but used as a proxy for the whole alignment step
 reference_genome: ${DNFA_generatedDataRoot}/STARIndex/SA 
 
-${DNFA_generatedDataRoot}/STARIndex/SA: $(starBinDir)/STAR $(fa) $(gtf) 
-	$(MKDIR) $(@D)
+${DNFA_generatedDataRoot}/STARIndex/SA: $(starBinDir)/STAR $(fa) $(gtf) | $$(@D)
 	cd $(@D) && $< \
 	  --runThreadN 12 \
 	  --runMode genomeGenerate \
@@ -66,7 +63,68 @@ ${DNFA_generatedDataRoot}/STARIndex/SA: $(starBinDir)/STAR $(fa) $(gtf)
 	  --sjdbGTFfile $(word 3, $^) \
 	  --sjdbOverhang 75
 
-clean: clean_star clean_starindex clean_refgenome
+samDir=${DNFA_generatedDataRoot}/Analysis/2-pass
+bamDir=${DNFA_generatedDataRoot}/Analysis/Samsort
+testIDs1 = 1_S2_L001 1_S2_L002 1_S2_L003 1_S2_L004
+testIDs2 = 2_S3_L001 2_S3_L002 2_S3_L003 2_S3_L004
+testIDs = $(testIDs1) $(testIDs2)
+
+# The 'bamfiles' target depends on a list of files with names
+# like 'test1_S2_L003Aligned.sorted.bam'.
+bamfiles: $(foreach id, $(testIDs), $(bamDir)/test$(id)Aligned.sorted.bam)
+samfiles: samfiles1 samfiles2
+samfiles1: $(foreach id, $(testIDs1), $(samDir)/test1/test$(id)Aligned.out.sam)
+samfiles2: $(foreach id, $(testIDs2), $(samDir)/test2/test$(id)Aligned.out.sam)
+
+# For each .bam file we might want to build, locate a similarly-named
+# .sam file and execute 'samtools' on it.
+
+$(bamDir)/%.sorted.bam : $(samDir)/test1/%.out.sam | $$(@D)
+	 $(sam2bam)
+
+$(bamDir)/%.sorted.bam : $(samDir)/test2/%.out.sam | $$(@D)
+	 $(sam2bam)
+
+define sam2bam:
+	 rm -f $@.tmp.* && samtools sort $< -o $@
+endef
+
+$(samDir)/test1/%Aligned.out.sam : $(starBinDir)/STAR \
+                                   ${DNFA_raw_data_basedir}/test1/%_R1_001.fastq.gz \
+                                   ${DNFA_raw_data_basedir}/test1/%_R2_001.fastq.gz \
+                                   | $(gtf) reference_genome $$(@D)
+	$(alignTestData)
+
+$(samDir)/test2/%Aligned.out.sam : $(starBinDir)/STAR \
+                                   ${DNFA_raw_data_basedir}/test2/%_R1_001.fastq.gz \
+                                   ${DNFA_raw_data_basedir}/test2/%_R2_001.fastq.gz \
+                                   | $(gtf) reference_genome $$(@D)
+	$(alignTestData)
+
+define alignTestData =
+	$< \
+     --genomeDir ${DNFA_generatedDataRoot}/STARIndex \
+     --sjdbGTFfile $(word 1, $|) \
+     --runThreadN 12 \
+     --outFileNamePrefix $(@D)/$(*F) \
+     --readFilesIn $(word 2, $^) $(word 3, $^) \
+     --readFilesCommand zcat \
+     --twopassMode Basic
+endef
+
+${DNFA_starRoot}:
+	$(MKDIR) $@
+
+${DNFA_generatedDataRoot}/referenceGenome ${DNFA_generatedDataRoot}/STARIndex:
+	$(MKDIR) $@
+
+$(samDir)/test1 $(samDir)/test2 $(bamDir):
+	$(MKDIR) $@
+
+# Use "make clean" to remove all generated output.
+# Use sub-targets (e.g. "make clean_star") to remove selected
+# generated output.
+clean: clean_star clean_starindex clean_refgenome clean_bamfiles
 
 clean_star:
 	rm -rf ${DNFA_starRoot}
@@ -77,3 +135,7 @@ clean_starindex:
 clean_refgenome:
 	rm -rf ${DNFA_generatedDataRoot}/referenceGenome
 
+clean_bamfiles:
+	rm -rf $(bamDir)
+
+.PHONY: all clean clean_star clean_starindex clean_refgenome clean_bamfiles samfiles bamfiles


### PR DESCRIPTION
This version is altered to improve the accuracy of make's determination of whether a target should be rebuilt (notice the '|' designator for order-only prerequisites in a few places, which may need further fine-tuning).

Furthermore, various 'mkdir' operations are now consolidated using dependency chains, rather than recipes that attempt redundant directory creation.  Besides cleaning up the output, this should reduce any possibility of directory timestamps being tweaked (with consequent attempts to needlessly rebuild targets) for no good reason.

This version is also enhanced to build the reference genome, samfiles, and bamfiles, using "make bamfiles".  After additional testing is completed, the expectation is that the 'all' target will refer to 'bamfiles' rather than reference_genome.

Note that it may seem tempting, based on CPU capacity, to "make -j 2 bamfiles".  However bear in mind that this will start 2 parallel STAR processes that *each* want to consume 30G+ of RAM.  That may theoretically work on a workstation with 64G of RAM, but it cripples one that has only 48G.

An initial .PHONY target is added, but probably will need to be tweaked subsequently.