### PR TITLE
Multiple Makefile enhancements.

### DIFF
--- a/configuration.tmpl
+++ b/configuration.tmpl
@@ -8,4 +8,9 @@ export DNFA_genfilesRoot="/usr/local/DNFA-genfiles"
 export DNFA_generatedDataRoot="${DNFA_genfilesRoot}/data"
 export DNFA_starRoot="${DNFA_genfilesRoot}/STAR"
 
+# The project Makefile is able to extract individual files from
+# ${DNFA_raw_data_tarfile} to ${DNFA_raw_data_basedir} as needed.
+# Note that the path "Testrun\/Nextseq\ Test-32743727" will be
+# stripped from the extracted file, during extraction.
+export DNFA_raw_data_tarfile="~/Testrun-pristine.tar"
 export DNFA_raw_data_basedir="/usr/local/DNFA-rawdata/Testrun/Nextseq_Test-32743727"


### PR DESCRIPTION
1. Provide a rule to generate a .fastq.gz file from a .tar file that contains all such files.  In principle, this permits the Makefile to perform soup-to-nuts .bam file generation given an internet connection and a single .tar file with original test data.

2. Combine rules for unzipping Ensembl .fa and .gtf files.

3. Add rules for processing original data from tests 3-6 (the existing Makefile handled only tests 1-2).

4. Use a single 'samfiles' target, so that other samfilesN targets don't need to be listed in .PHONY.

5. Consolidate pattern-matching rules for generating .sam files.  The pattern matcher can account for the various test<FOO> directories in which .fastq.gz files are contained.

6. For .sam processing, move the Ensembl .gtf prerequisite from the order-only to the regular prerequisite section.  The reference_genome target must remain order-only to prevent .sam files from being needlessly regenerated -- it's not clear why -- but the .gtf file is not part of that problem.

7. Provide some extra 'mkdir' rules for generating output directories for newly-supported data sets.

8. Update the 'clean' targets to include .sam file output directories.

9. Update .PHONY to include additional non-file targets.