### PR TITLE
Get GTEx.R integrated and working with Makefile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,17 @@ GUNZIP=gunzip -k
 MKDIR=mkdir -m 755 -p
 
 # in accord with usual conventions, the first target is named 'all'
-all: singlecellanalysis asoanalysis
+all: genedbanalysis singlecellanalysis asoanalysis
+
+genedbanalysis: \
+  $(extDataDir)/GTEx_Analysis_v6p_RNA-seq_RNA-SeQCv1.1.8_gene_rpkm.gct.gz \
+  $(extDataDir)/GTEx_Data_V6_Annotations_SampleAttributesDS.txt
+
+$(extDataDir)/GTEx_Analysis_v6p_RNA-seq_RNA-SeQCv1.1.8_gene_rpkm.gct.gz: | $$(@D)
+	cd $(@D) && wget -nc http://storage.googleapis.com/gtex_analysis_v6p/rna_seq_data/$(@F)
+
+$(extDataDir)/GTEx_Data_V6_Annotations_SampleAttributesDS.txt: | $$(@D)
+	cd $(@D) && wget -nc http://storage.googleapis.com/gtex_analysis_v6p/annotations/$(@F)
 
 singlecellanalysis: $(extDataDir)/GSE72056_melanoma_single_cell_revised_v2.txt.gz
 

--- a/R/GTEx.R
+++ b/R/GTEx.R
@@ -1,17 +1,77 @@
 library(data.table)
 library(ggplot2)
 
+# TODO(dlroxe): unify this with identical function in data prep .R file.
+# Return the value of the DNFA_generatedDataRoot environment variable.  If
+# that variable isn't set, return "/usr/local/DNFA-genfiles/data".
+.getDataDir3 <- function() {
+  return(Sys.getenv("DNFA_generatedDataRoot", unset = "/usr/local/DNFA-genfiles/data"))
+}
 
-######################################################################################################
-.plotGene <- function(goi) {
-  go <- gene[gene$Description==goi,]
-  go<-t(go)
+# In case of difficulty coordinating with Makefile output, this function
+# can be adjusted to return some other string, e.g. return("~/foo.txt.gz").
+# In theory, we could return a URL to a .gz file here as well, but then it
+# would be difficult to ensure that the file remains available locally for
+# repeated invocations.  It should be possible to execute this program
+# many times after downloading the file only once.  A possible alternative
+# is to check the existence of the local file, then resort to a URL
+# if the local file is missing.
+.get_gtex_data_filename <- function() {
+  local_file = file.path(
+    .getDataDir3(),
+    "r-extdata",
+    "GTEx_Analysis_v6p_RNA-seq_RNA-SeQCv1.1.8_gene_rpkm.gct.gz")
+  
+  if (file.exists(local_file)) {
+    return(local_file)
+  }
+  
+  # TODO(dlroxe): fread() supposedly supports URLs, but this seems not to work;
+  # for now it's best if the file exists locally (because it was fetched by the
+  # Makefile).
+  return("http://storage.googleapis.com/gtex_analysis_v6p/rna_seq_data/GTEx_Analysis_v6p_RNA-seq_RNA-SeQCv1.1.8_gene_rpkm.gct.gz")
+}
+
+.get_gtex_annotations_filename <- function() {
+  local_file = file.path(
+    .getDataDir3(),
+    "r-extdata",
+    "GTEx_Data_V6_Annotations_SampleAttributesDS.txt")
+  
+  if (file.exists(local_file)) {
+    return(local_file)
+  }
+  
+  # TODO(dlroxe): fread() supposedly supports URLs, but this seems not to work;
+  # for now it's best if the file exists locally (because it was fetched by the
+  # Makefile).
+  return("http://storage.googleapis.com/gtex_analysis_v6p/annotations/GTEx_Data_V6_Annotations_SampleAttributesDS.txt")
+}
+
+# Looks like this site might be a useful pointer towards a source for the data:
+# https://github.com/joed3/GTExV6PRareVariation
+## showProgress = T is necessary, otherwise "Error: isLOGICAL(showProgress) is not TRUE"
+.get_gene_rpkm <- function() {
+  gene <- data.table::fread(.get_gtex_data_filename(), header = T, showProgress = T)
+  return(gene)
+}
+
+.get_annotations <- function() {
+  Annotations <- data.table::fread(
+    .get_gtex_annotations_filename(), header = T, showProgress = T)
+  Annotations <- Annotations[,c(1,7)]
+  return(Annotations)
+}
+
+.plot_goi <- function(gene, Annotations, goi) {
+  go <- gene[gene$Description == goi,]
+  go <- t(go)
   ## SREBP1 is generated as a matrix somehow, and it needs to be converted into data frame
   go <- data.frame(go)
   setDT(go, keep.rownames = TRUE)[]
   colnames(go) <- c("SAMPID", "goi")
   #A one line option is: df$names<-rownames(df)
-  goexpression <- merge(go,Annotations,by='SAMPID')
+  goexpression <- merge(go, Annotations, by = 'SAMPID')
   ## somehow the numbers of SREBF1 columns are all changed into character 
   goexpression$SMTSD <- as.factor(goexpression$SMTSD)
   #  In particular, as.numeric applied to a factor is meaningless, and may happen by implicit coercion. 
@@ -19,32 +79,41 @@ library(ggplot2)
   goexpression$goi <- as.numeric(levels(goexpression$goi))[goexpression$goi]
   goexpression <- as.data.frame(goexpression)
   ## draw boxplot for FASN expression across different tissues
-  mean <- within(goexpression, SMTSD <-reorder(SMTSD, log2(goi), median))
-  ggplot(mean, aes(x=SMTSD, y=log2(goi))) + geom_boxplot()+ theme_bw()+ 
+  mean <- within(goexpression, SMTSD <- reorder(SMTSD, log2(goi), median))
+  black.bold.12pt <- ggplot2::element_text(face = "bold", size = 12, colour = "black")
+  genePlot <- ggplot(mean, aes(x = SMTSD, y = log2(goi))) + geom_boxplot() + theme_bw() + 
     labs(x = "Tissue types (GTEx)",
          y = paste("log2(", goi, "RNA counts)")) +
-    theme(axis.title=element_text(face="bold",size=12,color="black"),
-          axis.text=element_text(size=12,angle = 90, hjust = 1, face="bold",color="black"),
-          axis.line.x = element_line(color="black"),
-          axis.line.y = element_line(color="black"),
-          panel.grid = element_blank(),
-          strip.text = element_text(face = "bold", size = 12, colour = "black"),
-          legend.text = element_text(size=12,face="bold",colour = 'black'),
-          legend.title = element_text(face = "bold", size = 12, colour = "black"),
-          legend.justification=c(1,1))+ guides(fill=guide_legend(title=NULL))
+    theme(axis.title = black.bold.12pt,
+          axis.text = ggplot2::element_text(size = 12, angle = 90, hjust = 1, face = "bold", color = "black"),
+          axis.line.x = ggplot2::element_line(color = "black"),
+          axis.line.y = ggplot2::element_line(color = "black"),
+          panel.grid = ggplot2::element_blank(),
+          strip.text = black.bold.12pt,
+          legend.text = black.bold.12pt,
+          legend.title = black.bold.12pt,
+          legend.justification = c(1,1)) + guides(fill = guide_legend(title = NULL))
+  print(genePlot)
 }
 
-doAll5 <- function() {
-gene <- fread("GTEx_Analysis_v6p_RNA-seq_RNA-SeQCv1.1.8_gene_rpkm.csv",showProgress = T)
-Annotations <- fread("GTEx_Data_V6_Annotations_SampleAttributesDS.txt",showProgress = T)
-Annotations <-Annotations[,c(1,7)]
-## showProgress = T is necessary, otherwise "Error: isLOGICAL(showProgress) is not TRUE"
+doGTEX <- function() {
+  gene_rpkm <- .get_gene_rpkm()
+  Annotations <- .get_annotations()
 
-.plotGene(goi="FASN")
-.plotGene(goi="SCD")
-.plotGene(goi="SREBF1")
-.plotGene(goi="HMGCR")
-.plotGene(goi="HMGCS1")
-.plotGene(goi="SREBF2")
-.plotGene(goi="MITF")
-}  
+  plot1 <- .plot_goi(gene_rpkm, Annotations, goi = "FASN")
+  plot2 <- .plot_goi(gene_rpkm, Annotations, goi = "SCD")
+  plot3 <- .plot_goi(gene_rpkm, Annotations, goi = "SREBF1")
+  plot4 <- .plot_goi(gene_rpkm, Annotations, goi = "HMGCR")
+  plot5 <- .plot_goi(gene_rpkm, Annotations, goi = "HMGCS1")
+  plot6 <- .plot_goi(gene_rpkm, Annotations, goi = "SREBF2")
+  plot7 <- .plot_goi(gene_rpkm, Annotations, goi = "MITF")
+  print(plot1)
+  print(plot2)
+  print(plot3)
+  print(plot4)
+  print(plot5)
+  print(plot6)
+  print(plot7)
+}
+
+doGTEX()

--- a/README.md
+++ b/README.md
@@ -212,9 +212,15 @@ The commands `make` or `make all` will build everything, from soup to nuts.
 The following specific workflows are also supported:
 
 ## DNFA gene expression analysis with TCGA and GTEx databases.
-(Automated workflow still under development.)
+This depends on Makefile, R/TCGA.R, R/GTEx.R, R/Xena.R
 
-This depends on R/TCGA.R, R/GTEx.R, R/Xena.R
+Specific targets associated with this workflow include the following:
+* `make genedbanalysis` -- downloads public GTEX data and annotations
+    to the r-extdata directory under the directory named by they
+    configured environment variable `DNFA_generatedDataRoot`.
+
+For the time being, the R scripts must still be manually invoked after
+the data is downloaded.
 
 ## DNFA gene expression analysis on single cell RNA-seq dataset
 This depends on Makefile and R/scRNA-Seq.R.


### PR DESCRIPTION
1. Update Makefile to download all data used by GTEx.R.
2. Update README.md to describe what Makefile does to provide data for GTEx.R.
3. Refactor GTEx.R, so that it now generates all graphs when 'source' is clicked in RStudio (after "make" or "make genedbanalysis" is executed).