### PR TITLE
README.md updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,78 +124,6 @@ foolproof.  If in doubt, it is best to `make clean` and re-execute.
 Note that there are also more fine-grained 'clean' targets, to permit
 isolated re-exeuctions of portions of thr processing pipeline.
 
-# Software Engineering Discussion for Biologists
-
-## Build Systems
-
-One aspect of this project is a file named `Makefile`.  To a non-initiate,
-its contents undoubtedly appear as though, periodically during its creation,
-a cat walked across a keyboard with a stuck `shift` key, taking particular
-care to step only on the number keys.  However the file in fact specifies
-many specific buildable units, and the relationships between them.
-
-### A Primer on Makefiles
-
-Putting aside the meanings of various symbols, the basic idea is
-straightforward.  The Makefile provides a set of rules with the following
-form (as described in the
-[documentation for GNU Make](https://www.gnu.org/software/make/manual/html_node/Rule-Introduction.html#Rule-Introduction)):
-```
-target : prerequisites
-    recipe
-```
-
-The basic idea is: to 'make' a target, first verify the existence
-of its prerequisites, then execute a recipe.
-
-The value starts to become more apparent with just a slightly adjusted example:
-```
-target2 : target1
-    recipe2
-
-target1 :
-    recipe1
-```
-
-In this case, `make target2` will check for the existence of target1.  If
-target1 exists, then 'make' will execute recipe2.  If target1 does not exist,
-'make' will notice that target1 is *itself* a target.  Since target1 has no
-prerequisites, it will execute recipe1 and thereby generate target1.  Then,
-with target2's prerequisites satisfied, it will execute recipe2.
-
-In this way it is possible to specify a detailed protocol to produce a
-particular target.  When multiple dependencies exist, 'make' can keep track of
-which ones have been updated, and how they affect the rest of the target
-hierarchy, and rebuild other targets as needed.  When targets are well
-specified, it is often possible to delete and regenerate a very specific output
-in isolation.
-
-### The Wider World of Build Systems
-
-In fact, 'make' is just one of many things like 'make'.  It is one of the
-oldest, and its Makefile syntax produces some of the most arcane project
-descriptions.
-
-Alternatives include Python's 'snakemake' and Google's 'bazel'
-([don't call it 'blaze'](https://bazel.build/faq.html#whats-up-with-the-word-blaze-in-the-codebase)).
-
-This project uses 'make' because it is very well-established.  Users
-of this package most likely will not need to undertake any special steps
-to install it, nor does the package itself need to make any provision for
-such installation.  The downside is notoriously arcane Makefile syntax, but
-that is mostly a burden for project contributors rather than users.  Without
-caring about the actual contents of the Makefile, users can easily
-understand and execute an instruction like this:
-
-`make /opt/dnfa_genfiles/data/Analysis/Samsort/test2_S3_L004Aligned.sorted.bam`.
-
-If you consider using 'make' for one of your own projects, good advice
-would be: don't start by copying this project's Makefile and trying to
-adjust it for your purposes.  Rather, just start out with some very simple
-targets, then start learning and using automatic variables, one or two at
-a time. Eventually you will find that your project has a gibberish Makefile
-too, but to your surprise it will work, and to your even greater surprise
-you will understand it. (Well, that's not a promise, on either count.  YMMV.)
 
 # Workflows Provided by This Project
 
@@ -279,3 +207,84 @@ Specific targets associated with this workflow include the following:
 
 This depends on: ChIP-Seq/MACSandHOMERforChIP-Seq.sh, R/ChIPseeker.R,
 R/DESeqandGAGEforPathwayAnalysis.R.
+
+# Software Engineering Discussion for Biologists
+
+## Build Systems
+
+One aspect of this project is a file named `Makefile`.  To a non-initiate,
+its contents undoubtedly appear as though, periodically during its creation,
+a cat walked across a keyboard with a stuck `shift` key, taking particular
+care to step only on the number keys.  However the file in fact specifies
+many specific buildable units, and the relationships between them.
+
+### A Primer on Makefiles
+
+Putting aside the meanings of various symbols, the basic idea is
+straightforward.  The Makefile provides a set of rules with the following
+form (as described in the
+[documentation for GNU Make](https://www.gnu.org/software/make/manual/html_node/Rule-Introduction.html#Rule-Introduction)):
+```
+target : prerequisites
+    recipe
+```
+
+The basic idea is: to 'make' a target, first verify the existence
+of its prerequisites, then execute a recipe.
+
+The value starts to become more apparent with just a slightly adjusted example:
+```
+target2 : target1
+    recipe2
+
+target1 :
+    recipe1
+```
+
+In this case, `make target2` will check for the existence of target1.  If
+target1 exists, then 'make' will execute recipe2.  If target1 does not exist,
+'make' will notice that target1 is *itself* a target.  Since target1 has no
+prerequisites, it will execute recipe1 and thereby generate target1.  Then,
+with target2's prerequisites satisfied, it will execute recipe2.
+
+In this way it is possible to specify a detailed protocol to produce a
+particular target.  When multiple dependencies exist, 'make' can keep track of
+which ones have been updated, and how they affect the rest of the target
+hierarchy, and rebuild other targets as needed.  When targets are well
+specified, it is often possible to delete and regenerate a very specific output
+in isolation.
+
+### The Wider World of Build Systems
+
+In fact, 'make' is just one of many things like 'make'.  It is one of the
+oldest, and its Makefile syntax produces some of the most arcane project
+descriptions.
+
+Alternatives include Python's 'snakemake' and Google's 'bazel'
+([don't call it 'blaze'](https://bazel.build/faq.html#whats-up-with-the-word-blaze-in-the-codebase)).
+
+This project uses 'make' because it is very well-established.  Users
+of this package most likely will not need to undertake any special steps
+to install it, nor does the package itself need to make any provision for
+such installation.  The downside is notoriously arcane Makefile syntax, but
+that is mostly a burden for project contributors rather than users.  Without
+caring about the actual contents of the Makefile, users can easily
+understand and execute an instruction like this:
+
+`make /opt/dnfa_genfiles/data/Analysis/Samsort/test2_S3_L004Aligned.sorted.bam`.
+
+If you consider using 'make' for one of your own projects, good advice
+would be: don't start by copying this project's Makefile and trying to
+adjust it for your purposes.  Rather, just start out with some very simple
+targets, then start learning and using automatic variables, one or two at
+a time. Eventually you will find that your project has a gibberish Makefile
+too, but to your surprise it will work, and to your even greater surprise
+you will understand it. (Well, that's not a promise, on either count.  YMMV.)
+
+## Unit Tests
+
+(this section is under construction)
+
+## Documentation
+
+(this section is under construction)


### PR DESCRIPTION
1. Move the 'softwware engineering' discussion to the bottom of the README -- it is useful for certain audiences but not the main attraction.

2. Add placeholders for testing and documentation discussions.