### PR TITLE
Updates and fixes for des_facto.

### DIFF
--- a/R/DESeqandFactoMineRforASOSpecificity.R
+++ b/R/DESeqandFactoMineRforASOSpecificity.R
@@ -118,7 +118,6 @@ library(survival)
 # (2) estimation of dispersion: estimateDispersions
 # (3) Negative Binomial GLM fitting and Wald statistics: nbinomWaldTest
 .getDDSRES <- function(ddsDE) {
-  ddsDE <- DESeq(dds)  
   ddsres <- results(ddsDE)  
   summary(ddsres)
   res <- data.frame(ddsres)

--- a/scripts/des_facto.R
+++ b/scripts/des_facto.R
@@ -4,6 +4,8 @@
 # this file assumes that its working directory
 # is the project root directory (the parent directory
 # of both 'scripts' and 'R')
+
+rm(list=ls())  # guarantee from-scratch execution: clear the global environment
 source(file.path('R', 'DESeqandFactoMineRforASOSpecificity.R'))
 
 analyze_aso_specificity()


### PR DESCRIPTION
1. Cause the global environment to be cleared for every execution.

2. Remove a line that tried to generate 'ddsDE' from .getDDSRes() -- 'ddsDE' is already passed in as a parameter.